### PR TITLE
Fix dxTemplate directive after modularization

### DIFF
--- a/karma.test.shim.js
+++ b/karma.test.shim.js
@@ -2,8 +2,7 @@
 Error.stackTraceLimit = Infinity;
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;
 
-__karma__.loaded = function () {
-};
+__karma__.loaded = function () {};
 
 function isSpecFile(path) {
   return /\.spec\.js$/.test(path);
@@ -31,6 +30,11 @@ System.import('karma.systemjs.conf.js')
     coreTesting.TestBed.initTestEnvironment(
             browserTesting.BrowserDynamicTestingModule,
             browserTesting.platformBrowserDynamicTesting());
+  })
+  .then(function() {
+    return System.import('jquery').then(function($) {
+      $.noConflict(true); 
+    });
   })
   .then(function() {
     return Promise.all(

--- a/src/core/dx.template.ts
+++ b/src/core/dx.template.ts
@@ -10,7 +10,8 @@ import {
 
 import { DxTemplateHost } from './dx.template-host';
 
-declare let $: any;
+declare function require(params: any): any;
+let $ = require('jquery');
 
 export class RenderData {
     model: any;


### PR DESCRIPTION
Fixes #178 

As an alternative solution we may completely remove jQuery dependency in this repo but it will require changes in DevExtreme. Should we do this even if DevExtreme will continue to use jQuery?