### PR TITLE
Fix infinite loop in watchers when comparing dates

### DIFF
--- a/src/core/watcher-helper.ts
+++ b/src/core/watcher-helper.ts
@@ -45,39 +45,24 @@ export class WatcherHelper {
     }
 
     private _isElementExpired(element: any) {
-        let isExpired = false;
-
         if (element) {
-            isExpired = element.getRootNode().nodeType !== DOCUMENT_NODE_TYPE;
+            return element.getRootNode().nodeType !== DOCUMENT_NODE_TYPE;
         }
-
-        return isExpired;
     }
 
     private _isDifferentValues(oldValue: any, newValue: any, deepCheck: boolean) {
-        let isDifferentValue = false;
-
         if (deepCheck && newValue instanceof (Object)) {
-            isDifferentValue = this._checkObjectsFields(newValue, oldValue);
-        } else {
-            isDifferentValue = oldValue !== newValue;
+            return this._checkObjectsFields(newValue, oldValue);
         }
-
-        return isDifferentValue;
+        return oldValue !== newValue;
     }
 
     private _checkObjectsFields(checkingFromObject: Object, checkingToObject: Object) {
-        let isDifferentObjects = false;
-
         for (let field in checkingFromObject) {
-            isDifferentObjects = checkingFromObject[field] !== checkingToObject[field];
-
-            if (isDifferentObjects) {
-                break;
+            if (checkingFromObject[field] > checkingToObject[field] || checkingFromObject[field] < checkingToObject[field]) {
+                return true;
             }
         }
-
-        return isDifferentObjects;
     }
 
     checkWatchers() {

--- a/tests/src/ui/data-grid.spec.ts
+++ b/tests/src/ui/data-grid.spec.ts
@@ -63,6 +63,6 @@ describe('DxDataGrid', () => {
             fixture.detectChanges();
 
             done();
-        }, 100);
+        }, 0);
     });
 });

--- a/tests/src/ui/data-grid.spec.ts
+++ b/tests/src/ui/data-grid.spec.ts
@@ -1,0 +1,68 @@
+/// <reference path="../../../typings/globals/jasmine/index.d.ts" />
+
+import {
+    Component,
+    ViewChildren,
+    QueryList
+} from '@angular/core';
+
+import {
+    TestBed
+} from '@angular/core/testing';
+
+import {
+    DxDataGridModule,
+    DxDataGridComponent
+} from '../../../dist';
+
+@Component({
+    selector: 'test-container-component',
+    template: ''
+})
+class TestContainerComponent {
+    dataSource = [{
+        string: 'String',
+        date: new Date(),
+        dateString: '1995/01/15',
+        boolean: true,
+        number: 10
+    }];
+    columns = [
+        { dataField: 'string' },
+        { dataField: 'date' },
+        { dataField: 'dateString', dataType: 'date' },
+        { dataField: 'boolean' },
+        { dataField: 'number' }
+    ];
+
+    @ViewChildren(DxDataGridComponent) innerWidgets: QueryList<DxDataGridComponent>;
+}
+
+
+describe('DxDataGrid', () => {
+
+    beforeEach(() => {
+        TestBed.configureTestingModule(
+            {
+                declarations: [TestContainerComponent],
+                imports: [DxDataGridModule]
+            });
+    });
+
+    // spec
+    it('should not fall into infinite loop', (done) => {
+        TestBed.overrideComponent(TestContainerComponent, {
+            set: {
+                template: '<dx-data-grid [columns]="columns" [dataSource]="dataSource"></dx-data-grid>'
+            }
+        });
+        let fixture = TestBed.createComponent(TestContainerComponent);
+        fixture.detectChanges();
+
+        setTimeout(() => {
+            fixture.detectChanges();
+
+            done();
+        }, 100);
+    });
+});


### PR DESCRIPTION
Reproduced with: 

```html
<dx-data-grid id="gridContainer"
    [dataSource]="[{ "HireDate": "1995/01/15" }]"
    [columns]="[{
        dataField: 'HireDate',
        dataType: 'date'
    }]"></dx-data-grid>
```